### PR TITLE
.NET core preview idea

### DIFF
--- a/episodes/episode3.md
+++ b/episodes/episode3.md
@@ -18,6 +18,7 @@ Cloud native is containers, microservices and serverless that run in multicloud 
 6. How do you maintain quality in these pipelines for your cloud native apps
 7. Just how much can you automate in your pipelines? Database, security, infrastructure (including things like dns) etc
 8. Some examples of Cloud Native pipelines
+9. Show how Azure DevOps can help you deploy .NET Core preview apps to Azure via self-containment and SDK selection (the first step in your build pipeline should be to specify which .NET SDK you want to use)
 
 ## Show Notes
 


### PR DESCRIPTION
Added a note in here about how AzDO could be used like we're using it now to publish .NET Core 3.0 Preview 7 builds of the dot.net web site. People ask a lot about how to get preview builds running on App Service, and i think AzDO makes this a breeze and it should be called out for customers.